### PR TITLE
Add PHP 8.3 & 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A PHP + Apache docker image with useful extensions preinstalled
 
 The following versions of the image are available:
-  - PHP 7.2
   - PHP 7.3
   - PHP 7.4
   - PHP 8.0

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 A PHP + Apache docker image with useful extensions preinstalled
 
 The following versions of the image are available:
-  - PHP 5.6
   - PHP 7.2
   - PHP 7.3
   - PHP 7.4
   - PHP 8.0
   - PHP 8.1
   - PHP 8.2
+  - PHP 8.3
+  - PHP 8.4
 
 Apache `mod_rewrite` has been activated.
 

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-versions=(7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4)
+versions=(7.3 7.4 8.0 8.1 8.2 8.3 8.4)
 
 for version in "${versions[@]}"; do
 

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-versions=(7.2 7.3 7.4 8.0 8.1 8.2)
+versions=(7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4)
 
 for version in "${versions[@]}"; do
 


### PR DESCRIPTION
PHP 5.6 was dropped in #18.
PHP 7.2 cannot be built anymore, as it is based on Debian 10 whose repositories are offline after the release of Debian 13.